### PR TITLE
fix: ec-site の RPC クライアントに 5 秒タイムアウトを設定

### DIFF
--- a/services/ec-site/handler.go
+++ b/services/ec-site/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
@@ -94,5 +95,6 @@ func pgTimestampToProto(ts pgtype.Timestamptz) *timestamppb.Timestamp {
 }
 
 func newProductServiceClient(baseURL string) productv1connect.ProductServiceClient {
-	return productv1connect.NewProductServiceClient(http.DefaultClient, baseURL)
+	httpClient := &http.Client{Timeout: 5 * time.Second}
+	return productv1connect.NewProductServiceClient(httpClient, baseURL)
 }


### PR DESCRIPTION
## Summary

Closes #8

ec-site → product-mgmt の RPC クライアントが `http.DefaultClient`（タイムアウト無制限）を使用していたため、下流サービス無応答時にゴルーチンが永久ブロックされる問題を修正。

## Changes

- `services/ec-site/handler.go` の `newProductServiceClient` で `http.DefaultClient` → `&http.Client{Timeout: 5 * time.Second}` に変更

## Test

- `just test`: 全サービスのテスト通過
- `just lint`: 全 linter 通過（golangci-lint, buf lint, oxlint）
- `grep http.DefaultClient` で本番コードからの除去を確認済み（テストコードの httptest 用途は対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)