### PR TITLE
feat: 全サービスに graceful shutdown とサーバータイムアウトを追加

### DIFF
--- a/services/customer-mgmt/main.go
+++ b/services/customer-mgmt/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -35,7 +38,6 @@ func main() {
 		slog.Error("failed to connect to database", "error", err)
 		os.Exit(1)
 	}
-	defer pool.Close()
 
 	queries := db.New(pool)
 
@@ -85,15 +87,44 @@ func main() {
 	e.Any(path+"*", echo.WrapHandler(handler))
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: h2c.NewHandler(e, &http2.Server{}),
+		Addr:         ":" + port,
+		Handler:      h2c.NewHandler(e, &http2.Server{}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
-	slog.Info("customer-mgmt service starting", "port", port)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("failed to start server", "error", err)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		slog.Info("customer-mgmt service starting", "port", port)
+		serveErr <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("failed to start server", "error", err)
+			pool.Close()
+			os.Exit(1)
+		}
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	slog.Info("shutting down server")
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		slog.Error("graceful shutdown timed out, forcing close", "error", err)
+		_ = server.Close()
+		pool.Close()
 		os.Exit(1)
 	}
+	pool.Close()
+	slog.Info("server stopped")
 }
 
 // newLoggingInterceptor returns a Connect unary interceptor that outputs

--- a/services/ec-site/main.go
+++ b/services/ec-site/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -35,7 +38,6 @@ func main() {
 		slog.Error("failed to connect to database", "error", err)
 		os.Exit(1)
 	}
-	defer pool.Close()
 
 	queries := db.New(pool)
 
@@ -95,15 +97,44 @@ func main() {
 	e.Any(cartPath+"*", echo.WrapHandler(cartHandler))
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: h2c.NewHandler(e, &http2.Server{}),
+		Addr:         ":" + port,
+		Handler:      h2c.NewHandler(e, &http2.Server{}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
-	slog.Info("ec-site service starting", "port", port)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("failed to start server", "error", err)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		slog.Info("ec-site service starting", "port", port)
+		serveErr <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("failed to start server", "error", err)
+			pool.Close()
+			os.Exit(1)
+		}
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	slog.Info("shutting down server")
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		slog.Error("graceful shutdown timed out, forcing close", "error", err)
+		_ = server.Close()
+		pool.Close()
 		os.Exit(1)
 	}
+	pool.Close()
+	slog.Info("server stopped")
 }
 
 // newLoggingInterceptor returns a Connect unary interceptor that outputs

--- a/services/product-mgmt/main.go
+++ b/services/product-mgmt/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"connectrpc.com/connect"
@@ -35,7 +38,6 @@ func main() {
 		slog.Error("failed to connect to database", "error", err)
 		os.Exit(1)
 	}
-	defer pool.Close()
 
 	queries := db.New(pool)
 
@@ -90,15 +92,44 @@ func main() {
 	admin.GET("/products", adminHandler.HandleProductList)
 
 	server := &http.Server{
-		Addr:    ":" + port,
-		Handler: h2c.NewHandler(e, &http2.Server{}),
+		Addr:         ":" + port,
+		Handler:      h2c.NewHandler(e, &http2.Server{}),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
-	slog.Info("product-mgmt service starting", "port", port)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		slog.Error("failed to start server", "error", err)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		slog.Info("product-mgmt service starting", "port", port)
+		serveErr <- server.ListenAndServe()
+	}()
+
+	select {
+	case err := <-serveErr:
+		if !errors.Is(err, http.ErrServerClosed) {
+			slog.Error("failed to start server", "error", err)
+			pool.Close()
+			os.Exit(1)
+		}
+	case <-ctx.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	slog.Info("shutting down server")
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		slog.Error("graceful shutdown timed out, forcing close", "error", err)
+		_ = server.Close()
+		pool.Close()
 		os.Exit(1)
 	}
+	pool.Close()
+	slog.Info("server stopped")
 }
 
 // newLoggingInterceptor returns a Connect unary interceptor that outputs


### PR DESCRIPTION
## Summary

Closes #7

全3サービス（ec-site, product-mgmt, customer-mgmt）に graceful shutdown とサーバータイムアウトを追加する。

## Changes

- `signal.NotifyContext` で `SIGTERM` / `SIGINT` を捕捉し、`server.Shutdown` で graceful に停止
- シャットダウンタイムアウト 10 秒。タイムアウト時は `server.Close()` で強制停止し非ゼロ終了
- `http.Server` に `ReadTimeout: 10s`, `WriteTimeout: 30s`, `IdleTimeout: 120s` を設定
- `defer pool.Close()` を削除し、シャットダウンシーケンス内で明示的に `pool.Close()` を呼出
- `ListenAndServe` のエラーをチャネル経由で main goroutine に返す構造に変更（起動失敗時もクリーンアップを実行）

## Test

- `just test`: 全サービスの既存テスト通過
- `just lint`: 0 issues
- pre-push hook (generate + check + test) 通過

## Review Notes

- Codex レビューで goroutine 内 `os.Exit(1)` によるクリーンアップバイパスと、`server.Shutdown` 失敗時の不明瞭な終了パスを指摘され修正済み
- 3サービスで同一パターンの適用だが、共通化は Issue スコープ外のため見送り

🤖 Generated with [Claude Code](https://claude.com/claude-code)