### PR TITLE
fix: エラーレスポンスから内部エラー詳細を除去する

### DIFF
--- a/services/customer-mgmt/handler.go
+++ b/services/customer-mgmt/handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
@@ -42,7 +43,8 @@ func (h *CustomerServiceHandler) CreateCustomer(
 		PasswordHash: string(hashedPassword),
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "CreateCustomer")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	return connect.NewResponse(&customerv1.CreateCustomerResponse{
@@ -59,7 +61,8 @@ func (h *CustomerServiceHandler) GetCustomer(
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("customer not found"))
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "GetCustomer")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	return connect.NewResponse(&customerv1.GetCustomerResponse{

--- a/services/customer-mgmt/main.go
+++ b/services/customer-mgmt/main.go
@@ -75,7 +75,8 @@ func main() {
 
 	e.GET("/health", func(c echo.Context) error {
 		if err := pool.Ping(c.Request().Context()); err != nil {
-			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy", "error": err.Error()})
+			slog.ErrorContext(c.Request().Context(), "health check failed", "error", err)
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy"})
 		}
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})

--- a/services/ec-site/handler.go
+++ b/services/ec-site/handler.go
@@ -35,17 +35,20 @@ func (h *CartServiceHandler) GetCart(
 		if errors.Is(err, pgx.ErrNoRows) {
 			cart, err = h.queries.CreateCart(ctx, customerID)
 			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, err)
+				slog.ErrorContext(ctx, "database error", "error", err, "method", "GetCart.CreateCart")
+				return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 			}
 		} else {
-			return nil, connect.NewError(connect.CodeInternal, err)
+			slog.ErrorContext(ctx, "database error", "error", err, "method", "GetCart.GetCartByCustomerID")
+			return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 		}
 	}
 
 	// List cart items
 	items, err := h.queries.ListCartItems(ctx, cart.ID)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "GetCart.ListCartItems")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	// Inter-service communication: fetch product info for each item (log only)

--- a/services/ec-site/main.go
+++ b/services/ec-site/main.go
@@ -85,7 +85,8 @@ func main() {
 
 	e.GET("/health", func(c echo.Context) error {
 		if err := pool.Ping(c.Request().Context()); err != nil {
-			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy", "error": err.Error()})
+			slog.ErrorContext(c.Request().Context(), "health check failed", "error", err)
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy"})
 		}
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})

--- a/services/product-mgmt/handler.go
+++ b/services/product-mgmt/handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
@@ -42,7 +43,8 @@ func (h *ProductServiceHandler) CreateProduct(
 		StockQuantity: int32(req.Msg.StockQuantity),
 	})
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "CreateProduct")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	return connect.NewResponse(&productv1.CreateProductResponse{
@@ -59,7 +61,8 @@ func (h *ProductServiceHandler) GetProduct(
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("product not found"))
 		}
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "GetProduct")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	return connect.NewResponse(&productv1.GetProductResponse{
@@ -75,7 +78,7 @@ func (h *ProductServiceHandler) GetProduct(
 //   - 商品が0件の場合、空の products スライスを持つレスポンスを返す（エラーにしない）
 //
 // エラー:
-//   - DB エラー時は connect.CodeInternal を返す（エラー情報を保持する）
+//   - DB エラー時は connect.CodeInternal を返す（エラー詳細はログに出力し、クライアントには汎用メッセージのみ返す）
 func (h *ProductServiceHandler) ListProducts(
 	ctx context.Context,
 	req *connect.Request[productv1.ListProductsRequest],
@@ -84,7 +87,8 @@ func (h *ProductServiceHandler) ListProducts(
 
 	products, err := h.store.ListProducts(ctx)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		slog.ErrorContext(ctx, "database error", "error", err, "method", "ListProducts")
+		return nil, connect.NewError(connect.CodeInternal, errors.New("internal server error"))
 	}
 
 	protoProducts := make([]*productv1.Product, 0, len(products))

--- a/services/product-mgmt/main.go
+++ b/services/product-mgmt/main.go
@@ -75,7 +75,8 @@ func main() {
 
 	e.GET("/health", func(c echo.Context) error {
 		if err := pool.Ping(c.Request().Context()); err != nil {
-			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy", "error": err.Error()})
+			slog.ErrorContext(c.Request().Context(), "health check failed", "error", err)
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{"status": "unhealthy"})
 		}
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})


### PR DESCRIPTION
## Summary

Closes #9

RPC ハンドラとヘルスチェックで生の DB エラーをクライアントに返していた情報漏洩リスクを修正。

## Changes

- **handler.go（3サービス・8箇所）**: `connect.NewError(connect.CodeInternal, err)` → `slog.ErrorContext` でログ出力 + `errors.New("internal server error")` に置換
- **main.go（3サービス・3箇所）**: ヘルスチェックレスポンスから `err.Error()` を除去し、`slog.ErrorContext` でログ出力

## Test

- `just test`: 全サービスのテスト通過
- `just lint`: 0 issues
- grep で `connect.NewError(connect.CodeInternal, err)` の残存がないこと、ヘルスチェックに `err.Error()` がないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)