### PR TITLE
feat: BatchGetProducts RPC を追加し GetCart の N+1 RPC を解消

### DIFF
--- a/proto/product/v1/product.proto
+++ b/proto/product/v1/product.proto
@@ -41,8 +41,36 @@ message ListProductsResponse {
   repeated Product products = 1;
 }
 
+message BatchGetProductsRequest {
+  repeated int64 ids = 1;
+}
+
+message BatchGetProductsResponse {
+  repeated Product products = 1;
+}
+
 service ProductService {
   rpc CreateProduct(CreateProductRequest) returns (CreateProductResponse);
   rpc GetProduct(GetProductRequest) returns (GetProductResponse);
   rpc ListProducts(ListProductsRequest) returns (ListProductsResponse);
+
+  // BatchGetProducts returns products for the given IDs.
+  //
+  // Pre:
+  //   - ids must contain at least 1 and at most 100 elements
+  //   - each id must be a positive integer
+  //
+  // Post:
+  //   - returns found products only; unknown IDs are silently omitted
+  //   - duplicate IDs are deduplicated; each product is returned at most once
+  //   - products are returned in arbitrary order (not guaranteed to match request order)
+  //
+  // Rejects:
+  //   INVALID_ARGUMENT — ids is empty, exceeds 100 elements, or contains non-positive values
+  //
+  // Defers:
+  //   存在しない ID に対するエラー通知は行わない（部分取得を許容）
+  rpc BatchGetProducts(BatchGetProductsRequest) returns (BatchGetProductsResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }

--- a/services/ec-site/handler.go
+++ b/services/ec-site/handler.go
@@ -48,14 +48,18 @@ func (h *CartServiceHandler) GetCart(
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
-	// Inter-service communication: fetch product info for each item (log only)
-	for _, item := range items {
-		_, err := h.productClient.GetProduct(ctx, connect.NewRequest(&productv1.GetProductRequest{
-			Id: item.ProductID,
+	// Fetch product info in batch (log only)
+	if len(items) > 0 {
+		productIDs := make([]int64, len(items))
+		for i, item := range items {
+			productIDs[i] = item.ProductID
+		}
+
+		_, err := h.productClient.BatchGetProducts(ctx, connect.NewRequest(&productv1.BatchGetProductsRequest{
+			Ids: productIDs,
 		}))
 		if err != nil {
-			slog.WarnContext(ctx, "failed to get product", "product_id", item.ProductID, "error", err)
-			continue
+			slog.WarnContext(ctx, "failed to batch get products", "error", err)
 		}
 	}
 

--- a/services/ec-site/handler_log_test.go
+++ b/services/ec-site/handler_log_test.go
@@ -97,11 +97,19 @@ func (r *mockRows) Conn() *pgx.Conn                              { return nil }
 // mockProductServiceClient は productv1connect.ProductServiceClient のテスト用モック。
 type mockProductServiceClient struct {
 	productv1connect.ProductServiceClient
-	GetProductFn func(ctx context.Context, req *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error)
+	GetProductFn       func(ctx context.Context, req *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error)
+	BatchGetProductsFn func(ctx context.Context, req *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error)
 }
 
 func (m *mockProductServiceClient) GetProduct(ctx context.Context, req *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error) {
 	return m.GetProductFn(ctx, req)
+}
+
+func (m *mockProductServiceClient) BatchGetProducts(ctx context.Context, req *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error) {
+	if m.BatchGetProductsFn != nil {
+		return m.BatchGetProductsFn(ctx, req)
+	}
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("not implemented"))
 }
 
 func (m *mockProductServiceClient) CreateProduct(_ context.Context, _ *connect.Request[productv1.CreateProductRequest]) (*connect.Response[productv1.CreateProductResponse], error) {
@@ -279,7 +287,7 @@ func TestGetCart_ProductFetchFailure_LogsWarn(t *testing.T) {
 
 	productErr := errors.New("service unavailable")
 	client := &mockProductServiceClient{
-		GetProductFn: func(_ context.Context, _ *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error) {
+		BatchGetProductsFn: func(_ context.Context, _ *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error) {
 			return nil, productErr
 		},
 	}
@@ -305,16 +313,12 @@ func TestGetCart_ProductFetchFailure_LogsWarn(t *testing.T) {
 		t.Fatal("expected at least one log record, got none")
 	}
 
-	// 各商品取得失敗について WARN ログが出ること（2アイテム = 2回）
+	// BatchGetProducts 失敗で WARN ログが1回出ること
 	warnCount := 0
 	for _, rec := range *records {
-		if rec.Level == slog.LevelWarn && rec.Message == "failed to get product" {
+		if rec.Level == slog.LevelWarn && rec.Message == "failed to batch get products" {
 			warnCount++
 
-			// product_id フィールドがスネークケースで含まれること
-			if _, ok := rec.Attrs["product_id"]; !ok {
-				t.Error("WARN log should contain 'product_id' attribute")
-			}
 			// error フィールドが含まれること
 			if _, ok := rec.Attrs["error"]; !ok {
 				t.Error("WARN log should contain 'error' attribute")
@@ -322,8 +326,8 @@ func TestGetCart_ProductFetchFailure_LogsWarn(t *testing.T) {
 		}
 	}
 
-	if warnCount != 2 {
-		t.Errorf("expected 2 WARN logs for 'failed to get product', got %d", warnCount)
+	if warnCount != 1 {
+		t.Errorf("expected 1 WARN log for 'failed to batch get products', got %d", warnCount)
 	}
 }
 
@@ -345,7 +349,7 @@ func TestGetCart_ProductFetchFailure_LogFieldValues(t *testing.T) {
 
 	productErr := errors.New("connection refused")
 	client := &mockProductServiceClient{
-		GetProductFn: func(_ context.Context, _ *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error) {
+		BatchGetProductsFn: func(_ context.Context, _ *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error) {
 			return nil, productErr
 		},
 	}
@@ -364,13 +368,6 @@ func TestGetCart_ProductFetchFailure_LogFieldValues(t *testing.T) {
 	}
 
 	rec := (*records)[0]
-
-	// product_id の値が 42 であること
-	if pid, ok := rec.Attrs["product_id"]; !ok {
-		t.Error("missing 'product_id' attribute")
-	} else if pid != int64(42) {
-		t.Errorf("product_id = %v, want 42", pid)
-	}
 
 	// error の値が productErr であること
 	if errVal, ok := rec.Attrs["error"]; !ok {
@@ -396,8 +393,8 @@ func TestGetCart_NewCartNormalFlow_NoLogs(t *testing.T) {
 	queries := db.New(scenario.newDBTX())
 
 	client := &mockProductServiceClient{
-		GetProductFn: func(_ context.Context, _ *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error) {
-			return connect.NewResponse(&productv1.GetProductResponse{}), nil
+		BatchGetProductsFn: func(_ context.Context, _ *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error) {
+			return connect.NewResponse(&productv1.BatchGetProductsResponse{}), nil
 		},
 	}
 
@@ -440,8 +437,8 @@ func TestGetCart_ExistingCart_NoLogs(t *testing.T) {
 	queries := db.New(scenario.newDBTX())
 
 	client := &mockProductServiceClient{
-		GetProductFn: func(_ context.Context, _ *connect.Request[productv1.GetProductRequest]) (*connect.Response[productv1.GetProductResponse], error) {
-			return connect.NewResponse(&productv1.GetProductResponse{}), nil
+		BatchGetProductsFn: func(_ context.Context, _ *connect.Request[productv1.BatchGetProductsRequest]) (*connect.Response[productv1.BatchGetProductsResponse], error) {
+			return connect.NewResponse(&productv1.BatchGetProductsResponse{}), nil
 		},
 	}
 

--- a/services/ec-site/handler_n1_test.go
+++ b/services/ec-site/handler_n1_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestGetCart_NoGetProductLoop は handler.go の GetCart メソッド内に
+// GetProduct の逐次呼び出しが存在しないことを go/ast で静的に検証する。
+// N+1 RPC の解消後は BatchGetProducts を使うため、GetProduct の呼び出しが
+// GetCart 内に残っていてはならない。
+func TestGetCart_NoGetProductLoop(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "handler.go", nil, 0)
+	if err != nil {
+		t.Fatalf("failed to parse handler.go: %v", err)
+	}
+
+	// GetCart メソッドの関数本体を探す
+	var getCartBody *ast.BlockStmt
+	ast.Inspect(f, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok {
+			return true
+		}
+		if fn.Name.Name == "GetCart" && fn.Body != nil {
+			getCartBody = fn.Body
+			return false
+		}
+		return true
+	})
+
+	if getCartBody == nil {
+		t.Fatal("GetCart function not found in handler.go")
+	}
+
+	// GetCart 本体内に "GetProduct" のセレクタ呼び出しがないことを確認
+	ast.Inspect(getCartBody, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name == "GetProduct" {
+			t.Errorf("GetCart contains a call to GetProduct at %s; expected BatchGetProducts to replace N+1 calls",
+				fset.Position(call.Pos()))
+		}
+		return true
+	})
+}

--- a/services/product-mgmt/db/queries/products.sql
+++ b/services/product-mgmt/db/queries/products.sql
@@ -21,3 +21,8 @@ SELECT id, name, description, price, stock_quantity, created_at, updated_at
 FROM products
 ORDER BY id
 LIMIT $1 OFFSET $2;
+
+-- name: GetProductsByIDs :many
+SELECT id, name, description, price, stock_quantity, created_at, updated_at
+FROM products
+WHERE id = ANY($1::bigint[]);

--- a/services/product-mgmt/handler.go
+++ b/services/product-mgmt/handler.go
@@ -21,6 +21,7 @@ type productStore interface {
 	GetProduct(ctx context.Context, id int64) (db.Product, error)
 	CreateProduct(ctx context.Context, arg db.CreateProductParams) (db.Product, error)
 	ListProducts(ctx context.Context) ([]db.Product, error)
+	GetProductsByIDs(ctx context.Context, ids []int64) ([]db.Product, error)
 }
 
 // コンパイル時に *db.Queries が productStore を満たすことを保証する。
@@ -93,6 +94,54 @@ func (h *ProductServiceHandler) ListProducts(
 	}
 
 	return connect.NewResponse(&productv1.ListProductsResponse{
+		Products: protoProducts,
+	}), nil
+}
+
+// BatchGetProducts handles the BatchGetProducts RPC.
+//
+// 動作:
+//   - ids が空、100 件超、または非正値を含む場合は INVALID_ARGUMENT を返す
+//   - ids に重複がある場合は検索前に除去し、各 product は高々 1 回返す
+//   - store.GetProductsByIDs で該当商品を一括取得する
+//   - 存在しない ID は無視し、見つかった商品のみ返す（部分取得）
+//   - 各 db.Product を dbProductToProto で protobuf メッセージに変換する
+//
+// エラー:
+//   - DB エラー時は connect.CodeInternal を返す
+func (h *ProductServiceHandler) BatchGetProducts(
+	ctx context.Context,
+	req *connect.Request[productv1.BatchGetProductsRequest],
+) (*connect.Response[productv1.BatchGetProductsResponse], error) {
+	ids := req.Msg.GetIds()
+	if len(ids) == 0 || len(ids) > 100 {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ids must contain between 1 and 100 elements"))
+	}
+
+	uniqueIDs := make([]int64, 0, len(ids))
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("ids must be positive"))
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+
+	products, err := h.store.GetProductsByIDs(ctx, uniqueIDs)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	protoProducts := make([]*productv1.Product, 0, len(products))
+	for _, product := range products {
+		protoProducts = append(protoProducts, dbProductToProto(product))
+	}
+
+	return connect.NewResponse(&productv1.BatchGetProductsResponse{
 		Products: protoProducts,
 	}), nil
 }

--- a/services/product-mgmt/handler_test.go
+++ b/services/product-mgmt/handler_test.go
@@ -21,9 +21,10 @@ import (
 // GetProductFn / CreateProductFn / ListProductsFn を差し替えることで、
 // 各テストケースの振る舞いを制御する。
 type mockListProductStore struct {
-	GetProductFn    func(ctx context.Context, id int64) (db.Product, error)
-	CreateProductFn func(ctx context.Context, arg db.CreateProductParams) (db.Product, error)
-	ListProductsFn  func(ctx context.Context) ([]db.Product, error)
+	GetProductFn       func(ctx context.Context, id int64) (db.Product, error)
+	CreateProductFn    func(ctx context.Context, arg db.CreateProductParams) (db.Product, error)
+	ListProductsFn     func(ctx context.Context) ([]db.Product, error)
+	GetProductsByIDsFn func(ctx context.Context, ids []int64) ([]db.Product, error)
 }
 
 func (m *mockListProductStore) GetProduct(ctx context.Context, id int64) (db.Product, error) {
@@ -45,6 +46,13 @@ func (m *mockListProductStore) ListProducts(ctx context.Context) ([]db.Product, 
 		return m.ListProductsFn(ctx)
 	}
 	return nil, errors.New("ListProducts not implemented")
+}
+
+func (m *mockListProductStore) GetProductsByIDs(ctx context.Context, ids []int64) ([]db.Product, error) {
+	if m.GetProductsByIDsFn != nil {
+		return m.GetProductsByIDsFn(ctx, ids)
+	}
+	return nil, errors.New("GetProductsByIDs not implemented")
 }
 
 // コンパイル時にインターフェース充足を保証する。
@@ -347,4 +355,223 @@ func TestListProducts_SingleProduct(t *testing.T) {
 	if resp.Msg.Products[0].Name != "唯一の商品" {
 		t.Errorf("Name = %q, want %q", resp.Msg.Products[0].Name, "唯一の商品")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests — BatchGetProducts RPC
+// ---------------------------------------------------------------------------
+
+func TestBatchGetProducts(t *testing.T) {
+	tests := []struct {
+		name string
+		// request
+		ids []int64
+		// store behavior
+		storeFn func(ctx context.Context, ids []int64) ([]db.Product, error)
+		// expectations
+		wantCode      connect.Code
+		wantErr       bool
+		wantCount     int
+		wantIDs       []int64 // expected product IDs in response (order-independent)
+		checkStoreIDs []int64 // IDs that should be passed to store (after dedup)
+	}{
+		{
+			name: "正常系: 複数IDで複数商品が返る",
+			ids:  []int64{1, 2, 3},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return []db.Product{
+					sampleDBProduct(1, "商品A", "説明A", 1000, 10),
+					sampleDBProduct(2, "商品B", "説明B", 2500, 5),
+					sampleDBProduct(3, "商品C", "説明C", 500, 100),
+				}, nil
+			},
+			wantCount: 3,
+			wantIDs:   []int64{1, 2, 3},
+		},
+		{
+			name: "正常系: 単一IDで1商品が返る",
+			ids:  []int64{42},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return []db.Product{
+					sampleDBProduct(42, "単一商品", "説明", 999, 1),
+				}, nil
+			},
+			wantCount: 1,
+			wantIDs:   []int64{42},
+		},
+		{
+			name: "正常系: 存在しないIDは無視（部分取得）",
+			ids:  []int64{1, 999},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				// ID=999 は存在しないので ID=1 のみ返す
+				return []db.Product{
+					sampleDBProduct(1, "商品A", "説明A", 1000, 10),
+				}, nil
+			},
+			wantCount: 1,
+			wantIDs:   []int64{1},
+		},
+		{
+			name: "正常系: 全IDが存在しない場合は空レスポンス",
+			ids:  []int64{998, 999},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return []db.Product{}, nil
+			},
+			wantCount: 0,
+		},
+		{
+			name: "正常系: 重複IDは除去される",
+			ids:  []int64{1, 2, 1, 2, 1},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return []db.Product{
+					sampleDBProduct(1, "商品A", "説明A", 1000, 10),
+					sampleDBProduct(2, "商品B", "説明B", 2500, 5),
+				}, nil
+			},
+			checkStoreIDs: []int64{1, 2},
+			wantCount:     2,
+			wantIDs:       []int64{1, 2},
+		},
+		{
+			name:     "異常系: 空のIDs",
+			ids:      []int64{},
+			wantErr:  true,
+			wantCode: connect.CodeInvalidArgument,
+		},
+		{
+			name:     "異常系: nilのIDs（空と同等）",
+			ids:      nil,
+			wantErr:  true,
+			wantCode: connect.CodeInvalidArgument,
+		},
+		{
+			name:     "異常系: 101件超のIDs",
+			ids:      make101IDs(),
+			wantErr:  true,
+			wantCode: connect.CodeInvalidArgument,
+		},
+		{
+			name:     "異常系: 非正値（0）を含む",
+			ids:      []int64{1, 0, 3},
+			wantErr:  true,
+			wantCode: connect.CodeInvalidArgument,
+		},
+		{
+			name:     "異常系: 非正値（負数）を含む",
+			ids:      []int64{1, -5, 3},
+			wantErr:  true,
+			wantCode: connect.CodeInvalidArgument,
+		},
+		{
+			name: "異常系: DBエラー時はCodeInternal",
+			ids:  []int64{1},
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return nil, errors.New("database connection lost")
+			},
+			wantErr:  true,
+			wantCode: connect.CodeInternal,
+		},
+		{
+			name: "境界値: ちょうど100件のIDs",
+			ids:  make100IDs(),
+			storeFn: func(_ context.Context, ids []int64) ([]db.Product, error) {
+				return []db.Product{sampleDBProduct(1, "商品1", "説明", 100, 1)}, nil
+			},
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedIDs []int64
+			store := &mockListProductStore{}
+			if tt.storeFn != nil {
+				store.GetProductsByIDsFn = func(ctx context.Context, ids []int64) ([]db.Product, error) {
+					capturedIDs = ids
+					return tt.storeFn(ctx, ids)
+				}
+			}
+			h := &ProductServiceHandler{store: store}
+
+			resp, err := h.BatchGetProducts(
+				context.Background(),
+				connect.NewRequest(&productv1.BatchGetProductsRequest{Ids: tt.ids}),
+			)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				var connectErr *connect.Error
+				if !errors.As(err, &connectErr) {
+					t.Fatalf("expected *connect.Error, got %T: %v", err, err)
+				}
+				if connectErr.Code() != tt.wantCode {
+					t.Errorf("error code = %v, want %v", connectErr.Code(), tt.wantCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if resp.Msg == nil {
+				t.Fatal("response message should not be nil")
+			}
+			if got := len(resp.Msg.Products); got != tt.wantCount {
+				t.Fatalf("products count = %d, want %d", got, tt.wantCount)
+			}
+
+			// wantIDs が指定されている場合、レスポンスに含まれるIDを検証（順序不問）
+			if tt.wantIDs != nil {
+				gotIDs := make(map[int64]bool)
+				for _, p := range resp.Msg.Products {
+					gotIDs[p.Id] = true
+				}
+				for _, wantID := range tt.wantIDs {
+					if !gotIDs[wantID] {
+						t.Errorf("expected product ID %d in response, but not found", wantID)
+					}
+				}
+			}
+
+			// checkStoreIDs が指定されている場合、storeに渡されたIDを検証（重複除去確認）
+			if tt.checkStoreIDs != nil {
+				wantSet := make(map[int64]bool)
+				for _, id := range tt.checkStoreIDs {
+					wantSet[id] = true
+				}
+				gotSet := make(map[int64]bool)
+				for _, id := range capturedIDs {
+					gotSet[id] = true
+				}
+				if len(gotSet) != len(wantSet) {
+					t.Errorf("store received %d unique IDs, want %d", len(gotSet), len(wantSet))
+				}
+				for id := range wantSet {
+					if !gotSet[id] {
+						t.Errorf("expected store to receive ID %d, but not found", id)
+					}
+				}
+			}
+		})
+	}
+}
+
+// make100IDs は境界値テスト用に 1..100 の ID スライスを返す。
+func make100IDs() []int64 {
+	ids := make([]int64, 100)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	return ids
+}
+
+// make101IDs は上限超過テスト用に 1..101 の ID スライスを返す。
+func make101IDs() []int64 {
+	ids := make([]int64, 101)
+	for i := range ids {
+		ids[i] = int64(i + 1)
+	}
+	return ids
 }


### PR DESCRIPTION
## Summary

Closes #10

`ec-site` の `GetCart` でカート内アイテムごとに `product-mgmt` の `GetProduct` RPC を逐次発行していた N+1 問題を、`BatchGetProducts` RPC の追加と一括呼び出しへの置換により解消。

## Changes

- `proto/product/v1/product.proto`: `BatchGetProducts` RPC、`BatchGetProductsRequest`/`BatchGetProductsResponse` メッセージを追加
- `services/product-mgmt/db/queries/products.sql`: `GetProductsByIDs` クエリを追加（`WHERE id = ANY($1::bigint[])`)
- `services/product-mgmt/handler.go`: `BatchGetProducts` ハンドラを実装（バリデーション・重複ID除去・部分取得）
- `services/ec-site/handler.go`: `GetCart` の N+1 `GetProduct` ループを `BatchGetProducts` 一括呼び出しに置換

## Test

- `services/product-mgmt/handler_test.go`: `TestBatchGetProducts`（テーブルドリブン11ケース: 正常系5、異常系5、境界値1）
- `services/ec-site/handler_n1_test.go`: `TestGetCart_NoGetProductLoop`（go/ast 静的解析で GetCart 内に GetProduct 呼び出しがないことを検証）
- `services/ec-site/handler_log_test.go`: 既存テストを `BatchGetProducts` ベースに更新
- `just test`: 全サービスの全テスト Green

## Review Notes

- Proto の Pre/Post/Rejects/Defers コメントは設計レビューで矛盾を修正済み（Pre から ID 存在性要求を除去、重複 ID の扱いを明記）
- DB エラーの `connect.NewError(connect.CodeInternal, err)` パターンは既存 RPC（GetProduct, CreateProduct, ListProducts）と一貫。サービス間エラーメッセージの最小化は全 RPC 横断で別途対応すべき

🤖 Generated with [Claude Code](https://claude.com/claude-code)