### PR TITLE
fix: product-mgmt から UnimplementedHandler の埋め込みを削除

### DIFF
--- a/services/product-mgmt/handler.go
+++ b/services/product-mgmt/handler.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	productv1 "github.com/nangashi/bmkr/gen/go/product/v1"
-	"github.com/nangashi/bmkr/gen/go/product/v1/productv1connect"
 	db "github.com/nangashi/bmkr/services/product-mgmt/db/generated"
 )
 
@@ -29,7 +28,6 @@ type productStore interface {
 var _ productStore = (*db.Queries)(nil)
 
 type ProductServiceHandler struct {
-	productv1connect.UnimplementedProductServiceHandler
 	store productStore
 }
 


### PR DESCRIPTION
## Summary

Closes #11

Connect RPC の `UnimplementedProductServiceHandler` 埋め込みを `product-mgmt` から削除し、3サービスで「埋め込まない」方針に統一する。

## Changes

- `services/product-mgmt/handler.go` の `ProductServiceHandler` 構造体から `productv1connect.UnimplementedProductServiceHandler` の埋め込みを削除
- 不要になった `productv1connect` パッケージの import を削除

## Test

- `just test`: 全サービスのテスト通過
- `just lint`: 全サービスで lint 0 issues
- `grep -rn "Unimplemented" services/*/handler.go`: 3サービスとも埋め込みなしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)