### PR TITLE
refactor: フロントエンド品質改善（Connect クライアント共通化・Tailwind 統一・定数共通化）

### DIFF
--- a/services/ec-site/frontend/src/api/client.ts
+++ b/services/ec-site/frontend/src/api/client.ts
@@ -1,0 +1,9 @@
+import { createClient } from "@connectrpc/connect";
+import { createConnectTransport } from "@connectrpc/connect-web";
+import { ProductService } from "@bmkr/bff/gen/product/v1/product_pb.js";
+import { CartService } from "@bmkr/bff/gen/ec/v1/cart_pb.js";
+
+const transport = createConnectTransport({ baseUrl: "/" });
+
+export const productClient = createClient(ProductService, transport);
+export const cartClient = createClient(CartService, transport);

--- a/services/ec-site/frontend/src/constants.ts
+++ b/services/ec-site/frontend/src/constants.ts
@@ -1,0 +1,2 @@
+// 認証未実装のための暫定措置。認証導入時に動的取得に変更予定。
+export const CUSTOMER_ID = BigInt(1);

--- a/services/ec-site/frontend/src/pages/CartPage.tsx
+++ b/services/ec-site/frontend/src/pages/CartPage.tsx
@@ -4,7 +4,15 @@ import { type Cart } from "@bmkr/bff/gen/ec/v1/cart_pb.js";
 import { cartClient } from "../api/client.js";
 import { CUSTOMER_ID } from "../constants.js";
 
-// CartPage はカートページを表示するコンポーネント。
+function CartButton(props: React.ButtonHTMLAttributes<HTMLButtonElement>): React.ReactElement {
+  return (
+    <button
+      {...props}
+      className={`rounded border border-border bg-gray-100 px-4 py-1 disabled:opacity-50${props.className !== undefined ? ` ${props.className}` : ""}`}
+    />
+  );
+}
+
 export function CartPage(): React.ReactElement {
   const [cart, setCart] = useState<Cart | null>(null);
   const [loading, setLoading] = useState(true);
@@ -95,25 +103,16 @@ export function CartPage(): React.ReactElement {
           <li key={item.id.toString()} className="border border-border rounded-lg p-4">
             <div>商品ID: {item.productId.toString()}</div>
             <div>数量: {item.quantity}</div>
-            <button
-              className="rounded border border-border bg-gray-100 px-4 py-1"
-              onClick={() => void handleUpdateQuantity(item.id, item.quantity + 1)}
-            >
+            <CartButton onClick={() => void handleUpdateQuantity(item.id, item.quantity + 1)}>
               +
-            </button>
-            <button
-              className="rounded border border-border bg-gray-100 px-4 py-1 disabled:opacity-50"
+            </CartButton>
+            <CartButton
               onClick={() => void handleUpdateQuantity(item.id, item.quantity - 1)}
               disabled={item.quantity <= 1}
             >
               -
-            </button>
-            <button
-              className="rounded border border-border bg-gray-100 px-4 py-1"
-              onClick={() => void handleRemoveItem(item.id)}
-            >
-              削除
-            </button>
+            </CartButton>
+            <CartButton onClick={() => void handleRemoveItem(item.id)}>削除</CartButton>
           </li>
         ))}
       </ul>

--- a/services/ec-site/frontend/src/pages/CartPage.tsx
+++ b/services/ec-site/frontend/src/pages/CartPage.tsx
@@ -1,16 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { Link } from "react-router";
-import { createClient } from "@connectrpc/connect";
-import { createConnectTransport } from "@connectrpc/connect-web";
-import { CartService, type Cart } from "@bmkr/bff/gen/ec/v1/cart_pb.js";
-
-const transport = createConnectTransport({
-  baseUrl: "/",
-});
-const cartClient = createClient(CartService, transport);
-
-// 固定の customer_id（認証スコープ外のため）
-const CUSTOMER_ID = BigInt(1);
+import { type Cart } from "@bmkr/bff/gen/ec/v1/cart_pb.js";
+import { cartClient } from "../api/client.js";
+import { CUSTOMER_ID } from "../constants.js";
 
 // CartPage はカートページを表示するコンポーネント。
 export function CartPage(): React.ReactElement {
@@ -95,25 +87,33 @@ export function CartPage(): React.ReactElement {
   }
 
   return (
-    <div style={{ display: "grid", gap: "16px" }}>
+    <div className="grid gap-4">
       <Link to="/">商品一覧に戻る</Link>
       <h1>カート</h1>
-      <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: "12px" }}>
+      <ul className="list-none m-0 p-0 grid gap-3">
         {cart.items.map((item) => (
-          <li
-            key={item.id.toString()}
-            style={{ border: "1px solid #d1d5db", borderRadius: "8px", padding: "16px" }}
-          >
+          <li key={item.id.toString()} className="border border-border rounded-lg p-4">
             <div>商品ID: {item.productId.toString()}</div>
             <div>数量: {item.quantity}</div>
-            <button onClick={() => void handleUpdateQuantity(item.id, item.quantity + 1)}>+</button>
             <button
+              className="rounded border border-border bg-gray-100 px-4 py-1"
+              onClick={() => void handleUpdateQuantity(item.id, item.quantity + 1)}
+            >
+              +
+            </button>
+            <button
+              className="rounded border border-border bg-gray-100 px-4 py-1 disabled:opacity-50"
               onClick={() => void handleUpdateQuantity(item.id, item.quantity - 1)}
               disabled={item.quantity <= 1}
             >
               -
             </button>
-            <button onClick={() => void handleRemoveItem(item.id)}>削除</button>
+            <button
+              className="rounded border border-border bg-gray-100 px-4 py-1"
+              onClick={() => void handleRemoveItem(item.id)}
+            >
+              削除
+            </button>
           </li>
         ))}
       </ul>

--- a/services/ec-site/frontend/src/pages/ProductDetailPage.tsx
+++ b/services/ec-site/frontend/src/pages/ProductDetailPage.tsx
@@ -1,18 +1,8 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, Link } from "react-router";
-import { createClient } from "@connectrpc/connect";
-import { createConnectTransport } from "@connectrpc/connect-web";
-import { ProductService, type Product } from "@bmkr/bff/gen/product/v1/product_pb.js";
-import { CartService } from "@bmkr/bff/gen/ec/v1/cart_pb.js";
-
-const transport = createConnectTransport({
-  baseUrl: "/",
-});
-const client = createClient(ProductService, transport);
-const cartClient = createClient(CartService, transport);
-
-// 固定の customer_id（認証スコープ外のため）
-const CUSTOMER_ID = BigInt(1);
+import { type Product } from "@bmkr/bff/gen/product/v1/product_pb.js";
+import { productClient, cartClient } from "../api/client.js";
+import { CUSTOMER_ID } from "../constants.js";
 
 // ProductDetailPage は商品詳細ページを表示するコンポーネント。
 //
@@ -66,7 +56,7 @@ export function ProductDetailPage(): React.ReactElement {
 
     async function loadProduct(): Promise<void> {
       try {
-        const response = await client.getProduct({ id: BigInt(productId) });
+        const response = await productClient.getProduct({ id: BigInt(productId) });
         if (cancelled) {
           return;
         }

--- a/services/ec-site/frontend/src/pages/ProductListPage.tsx
+++ b/services/ec-site/frontend/src/pages/ProductListPage.tsx
@@ -1,13 +1,7 @@
 import { useState, useEffect } from "react";
 import { Link } from "react-router";
-import { createClient } from "@connectrpc/connect";
-import { createConnectTransport } from "@connectrpc/connect-web";
-import { ProductService, type Product } from "@bmkr/bff/gen/product/v1/product_pb.js";
-
-const transport = createConnectTransport({
-  baseUrl: "/",
-});
-const client = createClient(ProductService, transport);
+import { type Product } from "@bmkr/bff/gen/product/v1/product_pb.js";
+import { productClient } from "../api/client.js";
 
 // ProductListPage は商品一覧ページを表示するコンポーネント。
 //
@@ -32,7 +26,7 @@ export function ProductListPage(): React.ReactElement {
 
     async function loadProducts(): Promise<void> {
       try {
-        const response = await client.listProducts({});
+        const response = await productClient.listProducts({});
         if (cancelled) {
           return;
         }


### PR DESCRIPTION
## Why

Closes #38

## What Changed

- `src/api/client.ts` を新規作成し、Connect transport と `productClient`/`cartClient` をモジュールスコープシングルトンとして export。3ページに重複していた初期化コードを削除
- `src/constants.ts` を新規作成し、`CUSTOMER_ID = BigInt(1)` を共通化（2ページから参照）
- `CartPage.tsx` の inline style（`display: "grid"`, `border: "1px solid #d1d5db"` 等）を Tailwind ユーティリティクラスに置換
- `CartPage.tsx` の 3 ボタンに共通 `CartButton` コンポーネントを抽出してスタイル重複を解消

## Design Decisions

### 方針検討での判断

| 項目 | 判断 | 理由 |
|------|------|------|
| Connect クライアント共通化パターン | モジュールスコープシングルトン（factory 関数・React Context ではなく）| @connectrpc/connect-web 公式推奨。3ページ規模では Context は過剰 |
| `button` スタイル | `ProductDetailPage.tsx` の既存パターン（`bg-gray-100`）に揃える | アプリ内一貫性を優先。将来のデザイントークン統一時に `bg-surface` へ移行可能 |
| `CUSTOMER_ID` | `constants.ts`（汎用定数）に配置 | `config.ts`（環境依存値）とは役割が異なる。認証導入時の変更箇所を 1 ファイルに集約 |

## Acceptance

受け入れ条件との対応:

| 受け入れ条件 | 対応 |
|-------------|------|
| `createConnectTransport` + `createClient` の初期化を `src/api/client.ts` に切り出し、3ページから参照 | ✅ `ProductListPage`, `ProductDetailPage`, `CartPage` の 3 ページが `../api/client.js` から import |
| `CartPage.tsx` の inline style を Tailwind CSS ユーティリティクラスに置き換える | ✅ `style={{...}}` を全て削除し、`grid gap-4`, `list-none m-0 p-0 grid gap-3`, `border border-border rounded-lg p-4` 等に置換 |
| `CUSTOMER_ID = BigInt(1)` を `src/constants.ts` に切り出し、2ファイルから参照 | ✅ `CartPage.tsx` と `ProductDetailPage.tsx` が `../constants.js` から import |

`tsc -b`, `just test`, `just lint`, `just fmt` すべて通過。